### PR TITLE
Mark worker helper with no coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,15 @@ known-first-party = ["dandi_s3_log_extraction"]
 "src/dandi_s3_log_extraction/_hidden_top_level_imports.py" = ["F401"]  # Must perform imports here even if not exposed
 
 
-# None of these environment variables need to be 'correct' with respect to test suite
+
 [tool.pytest.ini_options]
 markers = [
     "remote: mark a test as requiring remote resources",
+]
+
+
+
+[tool.coverage.run]
+omit = [
+    "src/dandi_s3_log_extraction/_parallel/_utils.py",
 ]


### PR DESCRIPTION
Reviewing and increasing coverage as much as reasonably possible

Tests wouldn't be feasible/appropriate since this is a private method (splitting into a separate package, such as `cbutils`) would then benefit from some unit tests