### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily_remote_tests.yml
+++ b/.github/workflows/daily_remote_tests.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   DailyTests:

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   DailyTests:

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -7,6 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   Tests:

--- a/.github/workflows/publish_to_pypi_on_github_release.yml
+++ b/.github/workflows/publish_to_pypi_on_github_release.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/remote_testing.yml
+++ b/.github/workflows/remote_testing.yml
@@ -7,6 +7,8 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions: {}
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,8 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions: {}
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/dandi/dandi-s3-log-extraction/security/code-scanning/6](https://github.com/dandi/dandi-s3-log-extraction/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/daily_tests.yml` so all jobs in this workflow get least-privilege token access by default.

Best single fix here: insert

```yaml
permissions: {}
```

at the workflow root (e.g., after `concurrency` and before `jobs`). This matches CodeQL’s suggested minimal starting point and is safe for the shown jobs, since neither clearly needs `GITHUB_TOKEN` write access. It also applies to both `DailyTests` and `NotifyOnFailure` unless overridden per job.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
