### PR TITLE
Add explicit empty permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/daily_remote_tests.yml
+++ b/.github/workflows/daily_remote_tests.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   DailyTests:

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   DailyTests:

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -7,6 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
 
   Tests:

--- a/.github/workflows/publish_to_pypi_on_github_release.yml
+++ b/.github/workflows/publish_to_pypi_on_github_release.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/remote_testing.yml
+++ b/.github/workflows/remote_testing.yml
@@ -7,6 +7,8 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions: {}
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,8 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions: {}
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
 


### PR DESCRIPTION
## Summary
This PR adds explicit `permissions: {}` declarations to all GitHub Actions workflows to follow security best practices by implementing the principle of least privilege.

## Key Changes
- Added `permissions: {}` to 6 workflow files:
  - `daily_remote_tests.yml`
  - `daily_tests.yml`
  - `deploy_tests_on_pull_request.yml`
  - `publish_to_pypi_on_github_release.yml`
  - `remote_testing.yml`
  - `testing.yml`

## Implementation Details
By explicitly setting `permissions: {}` at the workflow level, we ensure that GitHub Actions jobs run with no default permissions. This follows the principle of least privilege and improves the security posture of the CI/CD pipeline. Any specific permissions required by individual jobs can be explicitly granted at the job level if needed.

https://claude.ai/code/session_01RLZQKworRBnsyFiQkHh2Y4