### PR TITLE
Move IP regex from encrypted config to environment variable

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,33 @@
+name: Version Check
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+
+permissions: {}
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        run: |
+          git show origin/${{ github.base_ref }}:pyproject.toml > /tmp/base_pyproject.toml
+          PR_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          BASE_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('/tmp/base_pyproject.toml').read_text())['project']['version'])")
+          echo "Base version: $BASE_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "::error::Version has not been bumped. Please update the version in pyproject.toml."
+            exit 1
+          fi
+          echo "Version bumped from $BASE_VERSION to $PR_VERSION ✓"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Upcoming
 
+### ⚠️ Breaking
+
+- Replaced the encrypted `DROGON_IP_REGEX_ENCRYPTED` constant with an unencrypted `IPS_TO_SKIP` environment variable for the regular expression of Drogon IPs to skip during extraction. The `S3_LOG_EXTRACTION_PASSWORD` is no longer required by this package. ([#87](https://github.com/dandi/dandi-s3-log-extraction/pull/87))
+
 ### 🚀 Enhancement
 
 - Added `download` to `_dandi_extraction.awk` so extraction writes `download.txt` alongside the other per-request outputs. ([#68](https://github.com/dandi/dandi-s3-log-extraction/pull/68))

--- a/README.md
+++ b/README.md
@@ -42,22 +42,14 @@ Usage on the DANDI archive logs requires a bit more customization than the gener
 
 Begin by ensuring a special required environment variable is set:
 
-**S3_LOG_EXTRACTION_PASSWORD**
-  - Various sensitive information on Drogon is encrypted using this password, including:
-    - the IP index and geolocation caches.
-
-This allows us to store full IP information in a persistent way (in case we need to go back and do a lookup) while still being secure.
-
-```bash
-export S3_LOG_EXTRACTION_PASSWORD="ask_yarik_or_cody_for_password"
-```
-
 **IPS_TO_SKIP**
   - A regular expression matching all associated Drogon IPs, which are skipped during extraction.
 
 ```bash
 export IPS_TO_SKIP="ask_yarik_or_cody_for_regex"
 ```
+
+The `S3_LOG_EXTRACTION_PASSWORD` is no longer required by this package. It is only relevant if you opt in to the upstream `s3-log-extraction` encryption of the IP index and geolocation caches.
 
 In fresh environments, the cache should be specified as:
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,19 @@ Begin by ensuring a special required environment variable is set:
 
 **S3_LOG_EXTRACTION_PASSWORD**
   - Various sensitive information on Drogon is encrypted using this password, including:
-    - the regular expression for all associated Drogon IPs.
     - the IP index and geolocation caches.
 
 This allows us to store full IP information in a persistent way (in case we need to go back and do a lookup) while still being secure.
 
 ```bash
 export S3_LOG_EXTRACTION_PASSWORD="ask_yarik_or_cody_for_password"
+```
+
+**IPS_TO_SKIP**
+  - A regular expression matching all associated Drogon IPs, which are skipped during extraction.
+
+```bash
+export IPS_TO_SKIP="ask_yarik_or_cody_for_regex"
 ```
 
 In fresh environments, the cache should be specified as:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ allow-direct-references = true
 
 [project]
 name = "dandi-s3-log-extraction"
-version="1.0.2"
+version="1.1.0"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/dandi_s3_log_extraction/_regex/__init__.py
+++ b/src/dandi_s3_log_extraction/_regex/__init__.py
@@ -1,5 +1,0 @@
-from ._globals import DROGON_IP_REGEX_ENCRYPTED
-
-__all__ = [
-    "DROGON_IP_REGEX_ENCRYPTED",
-]

--- a/src/dandi_s3_log_extraction/_regex/_globals.py
+++ b/src/dandi_s3_log_extraction/_regex/_globals.py
@@ -1,7 +1,0 @@
-# Seems there were multiple IPs associated with Drogon, though it likely only utilizes the main one
-# Better safe than not though
-DROGON_IP_REGEX_ENCRYPTED = (
-    b"gAAAAABoLL5Cln6TyMSaPfd8Cu_EIDDnIg2I7R3i-eipDcKGr0DRHXfqIGoxO36CQhEyp4aPR0Ylxu8dF"
-    b"OKknTAICvDg7GV33y6dI8d1-C6GsBoSdihP2IYEMwUwasa_dYUEtuTRVz10B0TpZkocjuRPW-CfIPVDgF"
-    b"yVXF8AfFESS-yRiL5nueuYsoD6MlJHmHhX0PVRVef6"
-)

--- a/src/dandi_s3_log_extraction/extractors/_dandi_remote_s3_log_access_extractor.py
+++ b/src/dandi_s3_log_extraction/extractors/_dandi_remote_s3_log_access_extractor.py
@@ -1,9 +1,7 @@
+import os
 import pathlib
 
 import s3_log_extraction
-from s3_log_extraction.utils import encryption as _encryption
-
-from .._regex import DROGON_IP_REGEX_ENCRYPTED
 
 
 class DandiRemoteS3LogAccessExtractor(s3_log_extraction.extractors.RemoteS3LogAccessExtractor):
@@ -30,5 +28,5 @@ class DandiRemoteS3LogAccessExtractor(s3_log_extraction.extractors.RemoteS3LogAc
 
         self._relative_script_path = pathlib.Path(__file__).parent / "_dandi_extraction.awk"
 
-        ips_to_skip_regex = _encryption.decrypt_bytes(encrypted_data=DROGON_IP_REGEX_ENCRYPTED)
-        self._awk_env["IPS_TO_SKIP_REGEX"] = ips_to_skip_regex.decode("utf-8")
+        ips_to_skip_regex = os.environ.get("IPS_TO_SKIP", "")
+        self._awk_env["IPS_TO_SKIP_REGEX"] = ips_to_skip_regex

--- a/tests/test_dandi_extra_coverage.py
+++ b/tests/test_dandi_extra_coverage.py
@@ -58,18 +58,16 @@ def test_handle_max_workers_exceeds_cpu_count() -> None:
 
 
 @pytest.mark.ai_generated
-@pytest.mark.skipif(
-    not os.environ.get("S3_LOG_EXTRACTION_PASSWORD"),
-    reason="S3_LOG_EXTRACTION_PASSWORD not set",
-)
-def test_dandi_remote_extractor_init(tmp_path: pathlib.Path) -> None:
+def test_dandi_remote_extractor_init(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """DandiRemoteS3LogAccessExtractor.__init__ sets expected attributes."""
     from dandi_s3_log_extraction.extractors import DandiRemoteS3LogAccessExtractor
+
+    monkeypatch.setenv("IPS_TO_SKIP", "192.168.0.1|10.0.0.1")
 
     extractor = DandiRemoteS3LogAccessExtractor(cache_directory=tmp_path)
     assert extractor._relative_script_path.exists()
     assert "IPS_TO_SKIP_REGEX" in extractor._awk_env
-    assert len(extractor._awk_env["IPS_TO_SKIP_REGEX"]) > 0
+    assert extractor._awk_env["IPS_TO_SKIP_REGEX"] == "192.168.0.1|10.0.0.1"
     assert extractor.use_encryption is False
 
 


### PR DESCRIPTION
## Summary
This PR refactors how the Drogon IP regex is configured, moving it from an encrypted constant in the codebase to an environment variable (`IPS_TO_SKIP`). This improves flexibility and reduces the need for encryption/decryption of this particular configuration value.

## Key Changes
- **Removed encrypted IP regex storage**: Deleted `src/dandi_s3_log_extraction/_regex/` module that contained the encrypted `DROGON_IP_REGEX_ENCRYPTED` constant
- **Updated extractor initialization**: Modified `DandiRemoteS3LogAccessExtractor.__init__()` to read `IPS_TO_SKIP` from environment variables instead of decrypting a hardcoded value
- **Updated documentation**: Modified README.md to document the new `IPS_TO_SKIP` environment variable requirement and removed the note about IP regex encryption under `S3_LOG_EXTRACTION_PASSWORD`
- **Updated tests**: Removed the `S3_LOG_EXTRACTION_PASSWORD` skip condition from `test_dandi_remote_extractor_init()` and added monkeypatch to set `IPS_TO_SKIP` for the test, with assertion updated to verify the exact regex value

## Implementation Details
- The `IPS_TO_SKIP` environment variable is now read directly using `os.environ.get()` with an empty string as default
- The regex value is no longer decrypted and is used as-is from the environment
- This change simplifies the codebase by removing the encryption/decryption dependency for this particular configuration

https://claude.ai/code/session_01MTLAe7acwDAKiDTEdAa5ov